### PR TITLE
Fix reference bot config in the game-runner

### DIFF
--- a/game-runner/game-runner-config.json
+++ b/game-runner/game-runner-config.json
@@ -5,7 +5,7 @@
   "verbose-mode": true,
   "max-runtime-ms": 1000,
   "player-a": "../starter-bots/javascript",
-  "player-b": "../reference-bot/javascript",
+  "player-b": "../reference-bot/java",
   "max-request-retries": 10,
   "request-timeout-ms": 5000,
   "is-tournament-mode": true,


### PR DESCRIPTION
The game runner is referencing the incorrect folder in the reference bot folder. This will fix it to point to the java reference bot. Currently it is configured for javascript which does not exist.