### PR TITLE
Fixes state issues with hitting more than one block in a single game tick

### DIFF
--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/commands/BaseCarGameCommand.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/commands/BaseCarGameCommand.scala
@@ -29,23 +29,23 @@ abstract class BaseCarGameCommand extends RawCommand {
         val futurePositionWithinAllBounds = getFuturePositionWithinBlockNumberBounds(futurePositionWithLaneBounds);
 
         //handle collisions with map objects (obstacles => pickups)
-        val playerHitMud = carGameMap.pathIncludesMud(currentBlockThatHasBeenVacated, futurePositionWithinAllBounds);
-        if(playerHitMud) {
+        val playerHitMudCount = carGameMap.mudCountInPath(currentBlockThatHasBeenVacated, futurePositionWithinAllBounds);
+        for(a <- 0 until playerHitMudCount) {
             carGamePlayer.hitMud();
         }
 
-        val playerHitOil = carGameMap.pathIncludesOilSpill(currentBlockThatHasBeenVacated, futurePositionWithinAllBounds)
-        if (playerHitOil) {
+        val playerHitOilCount = carGameMap.oilSpillCountInPath(currentBlockThatHasBeenVacated, futurePositionWithinAllBounds)
+        for (a <- 0 until playerHitOilCount) {
             carGamePlayer.hitOil()
         }
 
-        val playerPickedUpOilItem = carGameMap.pathIncludesOilItem(currentBlockThatHasBeenVacated, futurePositionWithinAllBounds);
-        if(playerPickedUpOilItem) {
+        val playerPickedUpOilItemCount = carGameMap.oilItemCountInPath(currentBlockThatHasBeenVacated, futurePositionWithinAllBounds);
+        for (a <- 0 until playerPickedUpOilItemCount) {
             carGamePlayer.pickupOilItem()
         }
 
-        val playerPickedUpBoost = carGameMap.pathIncludesBoost(currentBlockThatHasBeenVacated, futurePositionWithinAllBounds);
-        if(playerPickedUpBoost) {
+        val playerPickedUpBoostCount = carGameMap.boostCountInPath(currentBlockThatHasBeenVacated, futurePositionWithinAllBounds);
+        for (a <- 0 until playerPickedUpBoostCount) {
             carGamePlayer.pickupBoost();
         }
 

--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/map/CarGameMap.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/map/CarGameMap.scala
@@ -33,11 +33,11 @@ class CarGameMap(players: util.List[Player], mapGenerationSeed: Int, lanes: Int,
 
     if (winningPlayers.size == 0) {
       return null;
-    } 
+    }
     else if (winningPlayers.size == 1) {
       val firstPlayerAcrossTheLine = winningPlayers(0);
       return firstPlayerAcrossTheLine;
-    } 
+    }
     else
     {
       val winnersSortedBySpeed = winningPlayers.sortBy(x => x.asInstanceOf[CarGamePlayer].getSpeed());
@@ -132,21 +132,17 @@ class CarGameMap(players: util.List[Player], mapGenerationSeed: Int, lanes: Int,
     return blockOfInterest;
   }
 
-  def pathIncludesMud(startPosition: BlockPosition, endPosition: BlockPosition): Boolean = {
-    val pathIncludesMud = pathIncludesMapObject(startPosition, endPosition, Config.MUD_MAP_OBJECT);
-    return pathIncludesMud;
-  }
+  def mudCountInPath(startPosition: BlockPosition, endPosition: BlockPosition): Int =
+    numberOfMapObjectsInPath(startPosition, endPosition, Config.MUD_MAP_OBJECT);
 
-  def pathIncludesOilSpill(startPosition: BlockPosition, endPosition: BlockPosition): Boolean =
-    pathIncludesMapObject(startPosition, endPosition, Config.OIL_SPILL_MAP_OBJECT)
+  def oilSpillCountInPath(startPosition: BlockPosition, endPosition: BlockPosition): Int =
+    numberOfMapObjectsInPath(startPosition, endPosition, Config.OIL_SPILL_MAP_OBJECT)
 
-  def pathIncludesOilItem(startPosition: BlockPosition, endPosition: BlockPosition): Boolean =
-    pathIncludesMapObject(startPosition, endPosition, Config.OIL_ITEM_MAP_OBJECT)
+  def oilItemCountInPath(startPosition: BlockPosition, endPosition: BlockPosition): Int =
+    numberOfMapObjectsInPath(startPosition, endPosition, Config.OIL_ITEM_MAP_OBJECT)
 
-  def pathIncludesBoost(startPosition: BlockPosition, endPosition: BlockPosition): Boolean = {
-    val pathIncludesBoost = pathIncludesMapObject(startPosition, endPosition, Config.BOOST_MAP_OBJECT);
-    return pathIncludesBoost;
-  }
+  def boostCountInPath(startPosition: BlockPosition, endPosition: BlockPosition): Int =
+    numberOfMapObjectsInPath(startPosition, endPosition, Config.BOOST_MAP_OBJECT);
 
   def applyOilToBlock(position: BlockPosition) =
     getBlock(position).setMapObject(Config.OIL_SPILL_MAP_OBJECT)
@@ -158,11 +154,26 @@ class CarGameMap(players: util.List[Player], mapGenerationSeed: Int, lanes: Int,
     val endBlockNumber = endPosition.getBlockNumber();
     val blocksWithObject =
       blocks.find(x =>
-        (x.getPosition().getLane() == endLane && x.getPosition().getBlockNumber() >= startBlockNumber && x.getPosition().getBlockNumber() <= endBlockNumber) &&
+        (x.getPosition().getLane() == endLane && x.getPosition().getBlockNumber() >= startBlockNumber && x.getPosition().getBlockNumber() <= endBlockNumber)
+            &&
           x.getMapObject() == mapObject
       );
     val pathIncludesObject = blocksWithObject.isDefined;
     return pathIncludesObject;
+  }
+
+  private def numberOfMapObjectsInPath(startPosition: BlockPosition, endPosition: BlockPosition, mapObject: Int): Int = {
+    val startLane = startPosition.getLane();
+    val startBlockNumber = startPosition.getBlockNumber();
+    val endLane = endPosition.getLane();
+    val endBlockNumber = endPosition.getBlockNumber();
+    val blocksWithObject =
+      blocks.count(x =>
+        (x.getPosition().getLane() == endLane && x.getPosition().getBlockNumber() >= startBlockNumber && x.getPosition().getBlockNumber() <= endBlockNumber)
+            &&
+            x.getMapObject() == mapObject
+      );
+    return blocksWithObject;
   }
 
   def getBlocks(): Array[Block] = {

--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/map/CarGameMap.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/map/CarGameMap.scala
@@ -167,11 +167,10 @@ class CarGameMap(players: util.List[Player], mapGenerationSeed: Int, lanes: Int,
     val startBlockNumber = startPosition.getBlockNumber();
     val endLane = endPosition.getLane();
     val endBlockNumber = endPosition.getBlockNumber();
-    val blocksWithObject =
-      blocks.count(x =>
-        (x.getPosition().getLane() == endLane && x.getPosition().getBlockNumber() >= startBlockNumber && x.getPosition().getBlockNumber() <= endBlockNumber)
-            &&
-            x.getMapObject() == mapObject
+    val blocksWithObject = blocks.count(b => (b.getPosition().getLane() == endLane 
+                                               && b.getPosition().getBlockNumber() >= startBlockNumber 
+                                               && b.getPosition().getBlockNumber() <= endBlockNumber)
+                                           && b.getMapObject() == mapObject
       );
     return blocksWithObject;
   }

--- a/game-engine/src/test/scala/MapObject_Boost_Tests.scala
+++ b/game-engine/src/test/scala/MapObject_Boost_Tests.scala
@@ -18,12 +18,23 @@ class MapObject_Boost_Tests extends FunSuite{
 
   test("Given players during race when player hits boost then player gains 1 boost powerup") {
     initialise()
-    val gameMap = TestHelper.initaliseGameWithMapObjectAt(1, 3, Config.BOOST_MAP_OBJECT);
+    val gameMap = TestHelper.initialiseGameWithMapObjectAt(1, 3, Config.BOOST_MAP_OBJECT);
     val testGamePlayer1 = TestHelper.getTestGamePlayer1();
 
     val testCarGamePlayer = testGamePlayer1.asInstanceOf[CarGamePlayer];
     nothingCommand.performCommand(gameMap, testGamePlayer1);
 
     assert(testCarGamePlayer.getPowerups().count(x => x == Config.BOOST_POWERUP_ITEM) == 1);
+  }
+
+  test("Given players during race when player hits boost twice then player gains 3 boost powerups") {
+    initialise()
+    val gameMap = TestHelper.initialiseGameWithMultipleSameMapObjectsAt(1, Array(3,4), Config.BOOST_MAP_OBJECT);
+    val testGamePlayer1 = TestHelper.getTestGamePlayer1();
+
+    val testCarGamePlayer = testGamePlayer1.asInstanceOf[CarGamePlayer];
+    nothingCommand.performCommand(gameMap, testGamePlayer1);
+
+    assert(testCarGamePlayer.getPowerups().count(x => x == Config.BOOST_POWERUP_ITEM) == 2);
   }
 }

--- a/game-engine/src/test/scala/MapObject_Mud_Tests.scala
+++ b/game-engine/src/test/scala/MapObject_Mud_Tests.scala
@@ -18,7 +18,7 @@ class MapObject_Mud_Tests extends FunSuite{
 
   test("Given players during race when player hits mud then speed is reduced") {
     initialise()
-    val gameMap = TestHelper.initaliseGameWithMapObjectAt(1, 3, Config.MUD_MAP_OBJECT);
+    val gameMap = TestHelper.initialiseGameWithMapObjectAt(1, 3, Config.MUD_MAP_OBJECT);
     val testGamePlayer1 = TestHelper.getTestGamePlayer1();
 
     val testCarGamePlayer = testGamePlayer1.asInstanceOf[CarGamePlayer];
@@ -28,9 +28,21 @@ class MapObject_Mud_Tests extends FunSuite{
     assert(testCarGamePlayer.speed == Config.SPEED_STATE_1);
   }
 
+  test("Given players during race when player hits mud twice then speed is reduced twice") {
+    initialise()
+    val gameMap = TestHelper.initialiseGameWithMultipleSameMapObjectsAt(1, Array(3,4), Config.MUD_MAP_OBJECT);
+    val testGamePlayer1 = TestHelper.getTestGamePlayer1();
+
+    val testCarGamePlayer = testGamePlayer1.asInstanceOf[CarGamePlayer];
+    testCarGamePlayer.speed = Config.SPEED_STATE_3;
+    nothingCommand.performCommand(gameMap, testGamePlayer1);
+
+    assert(testCarGamePlayer.speed == Config.SPEED_STATE_1);
+  }
+
   test("Given player that is boosting during race when player hits mud then speed is reduced and player is no longer boosting") {
     initialise()
-    val gameMap = TestHelper.initaliseGameWithMapObjectAt(1, 3, Config.MUD_MAP_OBJECT);
+    val gameMap = TestHelper.initialiseGameWithMapObjectAt(1, 3, Config.MUD_MAP_OBJECT);
     val testGamePlayer1 = TestHelper.getTestGamePlayer1();
 
     val testCarGamePlayer = testGamePlayer1.asInstanceOf[CarGamePlayer];
@@ -44,7 +56,7 @@ class MapObject_Mud_Tests extends FunSuite{
 
   test("Given player that is going slowest speed when player hits mud then player continues going slowest speed") {
     initialise()
-    val gameMap = TestHelper.initaliseGameWithMapObjectAt(1, 3, Config.MUD_MAP_OBJECT);
+    val gameMap = TestHelper.initialiseGameWithMapObjectAt(1, 3, Config.MUD_MAP_OBJECT);
     val testGamePlayer1 = TestHelper.getTestGamePlayer1();
 
     val testCarGamePlayer = testGamePlayer1.asInstanceOf[CarGamePlayer];

--- a/game-engine/src/test/scala/MapObject_Oil_Item_Tests.scala
+++ b/game-engine/src/test/scala/MapObject_Oil_Item_Tests.scala
@@ -18,12 +18,23 @@ class MapObject_Oil_Item_Tests extends FunSuite{
 
   test("Given players during race when player hits oil powerup then player gains 1 oil powerup") {
     initialise()
-    val gameMap = TestHelper.initaliseGameWithMapObjectAt(1, 3, Config.OIL_ITEM_MAP_OBJECT);
+    val gameMap = TestHelper.initialiseGameWithMapObjectAt(1, 3, Config.OIL_ITEM_MAP_OBJECT);
     val testGamePlayer1 = TestHelper.getTestGamePlayer1();
 
     val testCarGamePlayer = testGamePlayer1.asInstanceOf[CarGamePlayer];
     nothingCommand.performCommand(gameMap, testGamePlayer1);
 
     assert(testCarGamePlayer.getPowerups().count(x => x == Config.OIL_POWERUP_ITEM) == 1);
+  }
+
+  test("Given players during race when player hits 2 oil power ups then player gains 2 oil powerup") {
+    initialise()
+    val gameMap = TestHelper.initialiseGameWithMultipleSameMapObjectsAt(1, Array(3,4), Config.OIL_ITEM_MAP_OBJECT);
+    val testGamePlayer1 = TestHelper.getTestGamePlayer1();
+
+    val testCarGamePlayer = testGamePlayer1.asInstanceOf[CarGamePlayer];
+    nothingCommand.performCommand(gameMap, testGamePlayer1);
+
+    assert(testCarGamePlayer.getPowerups().count(x => x == Config.OIL_POWERUP_ITEM) == 2);
   }
 }

--- a/game-engine/src/test/scala/MapObject_Oil_Spill_Tests.scala
+++ b/game-engine/src/test/scala/MapObject_Oil_Spill_Tests.scala
@@ -18,7 +18,7 @@ class MapObject_Oil_Spill_Tests extends FunSuite{
 
   test("Given players during race when player hits oil then speed is reduced") {
     initialise()
-    val gameMap = TestHelper.initaliseGameWithMapObjectAt(1, 3, Config.OIL_SPILL_MAP_OBJECT);
+    val gameMap = TestHelper.initialiseGameWithMapObjectAt(1, 3, Config.OIL_SPILL_MAP_OBJECT);
     val testGamePlayer1 = TestHelper.getTestGamePlayer1();
 
     val testCarGamePlayer = testGamePlayer1.asInstanceOf[CarGamePlayer];
@@ -28,9 +28,21 @@ class MapObject_Oil_Spill_Tests extends FunSuite{
     assert(testCarGamePlayer.speed == Config.SPEED_STATE_1);
   }
 
+  test("Given players during race when player hits oil twice then speed is reduced twice") {
+    initialise()
+    val gameMap = TestHelper.initialiseGameWithMultipleSameMapObjectsAt(1, Array(3,4), Config.OIL_SPILL_MAP_OBJECT);
+    val testGamePlayer1 = TestHelper.getTestGamePlayer1();
+
+    val testCarGamePlayer = testGamePlayer1.asInstanceOf[CarGamePlayer];
+    testCarGamePlayer.speed = Config.SPEED_STATE_3;
+    nothingCommand.performCommand(gameMap, testGamePlayer1);
+
+    assert(testCarGamePlayer.speed == Config.SPEED_STATE_1);
+  }
+
   test("Given player that is boosting during race when player hits oil then speed is reduced and player is no longer boosting") {
     initialise()
-    val gameMap = TestHelper.initaliseGameWithMapObjectAt(1, 3, Config.OIL_SPILL_MAP_OBJECT);
+    val gameMap = TestHelper.initialiseGameWithMapObjectAt(1, 3, Config.OIL_SPILL_MAP_OBJECT);
     val testGamePlayer1 = TestHelper.getTestGamePlayer1();
 
     val testCarGamePlayer = testGamePlayer1.asInstanceOf[CarGamePlayer];
@@ -44,7 +56,7 @@ class MapObject_Oil_Spill_Tests extends FunSuite{
 
   test("Given player that is going slowest speed when player hits oil then player continues going slowest speed") {
     initialise()
-    val gameMap = TestHelper.initaliseGameWithMapObjectAt(1, 3, Config.OIL_SPILL_MAP_OBJECT);
+    val gameMap = TestHelper.initialiseGameWithMapObjectAt(1, 3, Config.OIL_SPILL_MAP_OBJECT);
     val testGamePlayer1 = TestHelper.getTestGamePlayer1();
 
     val testCarGamePlayer = testGamePlayer1.asInstanceOf[CarGamePlayer];

--- a/game-engine/src/test/scala/TestHelper.scala
+++ b/game-engine/src/test/scala/TestHelper.scala
@@ -39,7 +39,7 @@ object TestHelper {
     return gameMap;
   }
 
-  def initaliseGameWithMapObjectAt(lane: Int, blockNumber: Int, mapObject: Int): GameMap = {
+  def initialiseGameWithMapObjectAt(lane: Int, blockNumber: Int, mapObject: Int): GameMap = {
     val testPlayers = new Array[Player](2);
     testPlayers(0) = testPlayer1;
     testPlayers(1) = testPlayer2;
@@ -49,5 +49,19 @@ object TestHelper {
     gameMap.asInstanceOf[CarGameMap].placeObjectAt(lane, blockNumber, mapObject);
 
     return gameMap;
+  }
+
+  def initialiseGameWithMultipleSameMapObjectsAt(lane: Int, blockNumbers: Array[Int], mapObject: Int): GameMap = {
+      val testPlayers = new Array[Player](2);
+      testPlayers(0) = testPlayer1;
+      testPlayers(1) = testPlayer2;
+      val testPlayersJava = testPlayers.toList.asJava;
+      val gameMap = carMapGenerator.generateGameMap(testPlayersJava);
+      gameMap.asInstanceOf[CarGameMap].makeAllBlocksEmpty();
+      for (blockNumber <- blockNumbers) {
+          gameMap.asInstanceOf[CarGameMap].placeObjectAt(lane, blockNumber, mapObject);
+      }
+
+      return gameMap;
   }
 }


### PR DESCRIPTION
This fixes the issue with Mud, oil, and powerups only being applied once per round, no matter how many blocks are hit.