### PR TITLE
Attempt at fixing colision bug. 

### DIFF
--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/map/CarGameMap.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/map/CarGameMap.scala
@@ -215,7 +215,7 @@ class CarGameMap(players: util.List[Player], mapGenerationSeed: Int, lanes: Int,
         val player2WasBehindPlayer1 = (player2StagedPosition.getOldPosition().getBlockNumber() < player1StagedPosition.getOldPosition().getBlockNumber())
         val player2EndedUpInFrontOfPlayer1 = (player2FuturePosition.getBlockNumber() >= player1FuturePosition.getBlockNumber())
         val player2EndedUpInSameLaneAsPlayer1 = (player2FuturePosition.getLane() == player1FuturePosition.getLane())
-        val player2DroveIntoPlayer1 = player2WasInSameLaneAsPlayer1 && player2WasBehindPlayer1 && player2EndedUpInFrontOfPlayer1 && player2EndedUpInSameLaneAsPlayer1 && (playersFuturePositionsAreSame || !player1StagedPosition.getPlayer().isLizarding)
+        val player2DroveIntoPlayer1 = player2WasInSameLaneAsPlayer1 && player2WasBehindPlayer1 && player2EndedUpInFrontOfPlayer1 && player2EndedUpInSameLaneAsPlayer1 && (playersFuturePositionsAreSame || !player2StagedPosition.getPlayer().isLizarding)
 
         val isCollisionFromBehind = player1DroveIntoPlayer2 || player2DroveIntoPlayer1
 


### PR DESCRIPTION
Closes #72 

I am not sure if this is the full fix, but that seems like a copy-paste error, and seems to explain the weird behaviour as explained [here](https://forum.entelect.co.za/t/same-lane-overtake-with-front-player-using-lizard-jump/1019/5)
