### PR TITLE
Added tests for speed penalties for conditions discussed in #70

### DIFF
--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/map/CarGameMap.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/map/CarGameMap.scala
@@ -155,6 +155,7 @@ class CarGameMap(players: util.List[Player], mapGenerationSeed: Int, lanes: Int,
 
     def resolveCyberTruckCollisions(): Boolean = {
         var playerHitCyberTruck = false
+        var hitCyberTrucks = new Array[Block](0)
         stagedFuturePositions.foreach(x => {
             val startBlockNumber = x.getOldPosition().getBlockNumber()
             val endBlockNumber = x.getNewPosition().getBlockNumber()
@@ -178,7 +179,7 @@ class CarGameMap(players: util.List[Player], mapGenerationSeed: Int, lanes: Int,
                     val newFuturePosition = new BlockPosition(adjustedNewLane, adjustedNewBlockNumber)
                     x.setNewPosition(newFuturePosition)
                     x.getPlayer().hitCyberTruck()
-                    definedBlockWithCyberTruck.removeCyberTruck()
+                    hitCyberTrucks = hitCyberTrucks :+ definedBlockWithCyberTruck
                     playerHitCyberTruck = true
                 }
                 else {
@@ -188,11 +189,16 @@ class CarGameMap(players: util.List[Player], mapGenerationSeed: Int, lanes: Int,
                     val newFuturePosition = new BlockPosition(adjustedNewLane, adjustedNewBlockNumber)
                     x.setNewPosition(newFuturePosition)
                     x.getPlayer().hitCyberTruck()
-                    definedBlockWithCyberTruck.removeCyberTruck()
+                    hitCyberTrucks = hitCyberTrucks :+ definedBlockWithCyberTruck
                     playerHitCyberTruck = true
                 }
             }
         })
+
+        for (block <- hitCyberTrucks) {
+          block.removeCyberTruck()
+        }
+
         return playerHitCyberTruck
     }
 

--- a/game-engine/src/test/scala/Command_Tweet_Tests.scala
+++ b/game-engine/src/test/scala/Command_Tweet_Tests.scala
@@ -9,9 +9,11 @@ import za.co.entelect.challenge.game.contracts.map.{BlockPosition, CarGameMap}
 class Command_Tweet_Tests extends FunSuite{
   private val commandText = "NOTHING"
   private val turnRightCommandText = "TURN_RIGHT"
+  private val accelerateCommandText = "ACCELERATE"
   private var commandFactory: CommandFactory = null
   private var nothingCommand: RawCommand = null
   private var turnRightCommand: RawCommand = null
+  private var accelerateCommand: RawCommand = null
 
   def initialise() = {
     Config.loadDefault()
@@ -20,6 +22,8 @@ class Command_Tweet_Tests extends FunSuite{
     nothingCommand.setCommand(commandText)
     turnRightCommand = commandFactory.makeCommand(turnRightCommandText)
     turnRightCommand.setCommand(turnRightCommandText)
+    accelerateCommand = commandFactory.makeCommand(accelerateCommandText)
+    accelerateCommand.setCommand(accelerateCommandText)
   }
 
   def makeTweetCommand(laneX: Int, blockY: Int) : RawCommand =
@@ -768,21 +772,24 @@ class Command_Tweet_Tests extends FunSuite{
 
     val testGamePlayer1 = TestHelper.getTestGamePlayer1()
     val testCarGamePlayer1 = testGamePlayer1.asInstanceOf[CarGamePlayer]
-    TestHelper.putPlayerSomewhereOnTheTrack(carGameMap, testCarGamePlayer1.getGamePlayerId(), 2, 700)
+    TestHelper.putPlayerSomewhereOnTheTrack(carGameMap, testCarGamePlayer1.getGamePlayerId(), 3, 36)
 
     val testGamePlayer2 = TestHelper.getTestGamePlayer2()
     val testCarGamePlayer2 = testGamePlayer2.asInstanceOf[CarGamePlayer]
-    TestHelper.putPlayerSomewhereOnTheTrack(carGameMap, testCarGamePlayer2.getGamePlayerId(), 2, 702)
+    TestHelper.putPlayerSomewhereOnTheTrack(carGameMap, testCarGamePlayer2.getGamePlayerId(), 3, 40)
 
-    val blockForCyberTruck = carGameMap.getBlockMatchingPosition(new BlockPosition(2, 706))
+    testCarGamePlayer1.speed = 8
+    testCarGamePlayer2.speed = 8
+
+    val blockForCyberTruck = carGameMap.getBlockMatchingPosition(new BlockPosition(3, 43))
     blockForCyberTruck.addCyberTruck();
 
     assert(blockForCyberTruck.isOccupiedByCyberTruck())
 
-    TestHelper.processRound(carGameMap, nothingCommand, nothingCommand)
+    TestHelper.processRound(carGameMap, accelerateCommand, accelerateCommand)
 
-    assert(carGameMap.getPlayerBlockPosition(testCarGamePlayer1.getGamePlayerId()).getBlockNumber() == 704)
-    assert(carGameMap.getPlayerBlockPosition(testCarGamePlayer2.getGamePlayerId()).getBlockNumber() == 705)
+    assert(carGameMap.getPlayerBlockPosition(testCarGamePlayer1.getGamePlayerId()).getBlockNumber() == 41)
+    assert(carGameMap.getPlayerBlockPosition(testCarGamePlayer2.getGamePlayerId()).getBlockNumber() == 42)
   }
 
   test("Given a race when both players are in different lanes and turn into in the same lane behind each other and hit a cybertruck") {


### PR DESCRIPTION
Hi again, thanks for adding the test cases, I played around with it a bit more and I think a might have found an issue. If I'm understanding correctly, both cars hit the cybertruck which should mean that both cars get the speed penalty. I've added test cases for this but it seems that only one of the cars is getting the speed penalty. Is this the intended behaviour?