### PR TITLE
Update map gen + fix a bug where using a boost, lizard or oil without having any causes game crash

### DIFF
--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/commands/UseBoostCommand.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/commands/UseBoostCommand.scala
@@ -7,13 +7,11 @@ import za.co.entelect.challenge.game.contracts.map.BlockPosition
 class UseBoostCommand extends BaseCarGameCommand {
     override def getFuturePositionAfterAdditionalProcessingOfCommand(carGameMap: CarGameMap, carGamePlayer: CarGamePlayer, currentPlayerPosition: BlockPosition): BlockPosition = {
         val playerHasBoost = carGamePlayer.hasBoost()
-        if (playerHasBoost) 
-        {
+        if (playerHasBoost) {
             carGamePlayer.useBoost()
         }
-        else
-        {
-            //TODO: report match issues
+        else {
+            carGamePlayer.doNothing()
         }
         val futureBlockNumber = currentPlayerPosition.getBlockNumber() + carGamePlayer.getSpeed()
         val futurePosition = new BlockPosition(currentPlayerPosition.getLane(), futureBlockNumber)

--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/commands/UseEmpCommand.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/commands/UseEmpCommand.scala
@@ -21,7 +21,6 @@ class UseEmpCommand extends BaseCarGameCommand {
 
     }
     else {
-      //TODO: report match issues
       carGamePlayer.doNothing()
     }
 

--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/commands/UseLizardCommand.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/commands/UseLizardCommand.scala
@@ -7,6 +7,9 @@ class UseLizardCommand extends BaseCarGameCommand {
         if (carGamePlayer.hasLizard){
             carGamePlayer.useLizard()
         }
+        else {
+          carGamePlayer.doNothing()
+        }
         return CommandHelper.getFuturePosition(carGamePlayer, currentPlayerPosition)
     }
 }

--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/commands/UseOilCommand.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/commands/UseOilCommand.scala
@@ -17,7 +17,7 @@ class UseOilCommand extends BaseCarGameCommand {
             carGameMap.applyOilToBlock(blockToPlaceOil)
         }
         else {
-            //TODO: report match issues
+            carGamePlayer.doNothing()
         }
         return futurePosition
     }

--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/commands/UseTweetCommand.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/commands/UseTweetCommand.scala
@@ -17,7 +17,6 @@ class UseTweetCommand(lane: Int, block: Int) extends BaseCarGameCommand {
       carGameMap.stageCyberTruckAt(stagedCyberTruckPosition)
     }
     else {
-      //TODO: report match issues
       carGamePlayer.doNothing()
     }
 

--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarMapGenerator.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarMapGenerator.scala
@@ -64,12 +64,12 @@ class CarMapGenerator(seed: Int) extends GameMapGenerator {
         val mapObjects = mutable.SortedMap[Double, Int]()
         mapObjects.put(0.0, Config.EMPTY_MAP_OBJECT)
         mapObjects.put(((Config.MUD_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.29, Config.MUD_MAP_OBJECT)
-        mapObjects.put(mapObjects.lastKey + ((Config.BOOST_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.189, Config.BOOST_MAP_OBJECT)
-        mapObjects.put(mapObjects.lastKey + ((Config.OIL_ITEM_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.197, Config.OIL_ITEM_MAP_OBJECT)
-        mapObjects.put(mapObjects.lastKey + ((Config.WALL_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.26, Config.WALL_MAP_OBJECT)
-        mapObjects.put(mapObjects.lastKey + ((Config.LIZARD_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.2, Config.LIZARD_MAP_OBJECT)
-        mapObjects.put(mapObjects.lastKey + ((Config.TWEET_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.173, Config.TWEET_MAP_OBJECT)
-        mapObjects.put(mapObjects.lastKey + ((Config.EMP_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.165, Config.EMP_MAP_OBJECT)
+        mapObjects.put(mapObjects.lastKey + ((Config.BOOST_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.182, Config.BOOST_MAP_OBJECT)
+        mapObjects.put(mapObjects.lastKey + ((Config.OIL_ITEM_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.2, Config.OIL_ITEM_MAP_OBJECT)
+        mapObjects.put(mapObjects.lastKey + ((Config.WALL_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.165, Config.WALL_MAP_OBJECT)
+        mapObjects.put(mapObjects.lastKey + ((Config.LIZARD_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.185, Config.LIZARD_MAP_OBJECT)
+        mapObjects.put(mapObjects.lastKey + ((Config.TWEET_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.2, Config.TWEET_MAP_OBJECT)
+        mapObjects.put(mapObjects.lastKey + ((Config.EMP_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.21, Config.EMP_MAP_OBJECT)
         mapObjects.put(1.0, Config.EMPTY_MAP_OBJECT)
 
         //generate empty map
@@ -81,16 +81,14 @@ class CarMapGenerator(seed: Int) extends GameMapGenerator {
             blocks(i) = new Block(position, generatedMapObject, Config.EMPTY_PLAYER)
         }
 
-        val zIndexForObstacles = 0.1
-        blockObjectCreator.placeObjectOnTrack(blocks, mapObjects, Config.MUD_MAP_OBJECT, zIndexForObstacles)
-        blockObjectCreator.placeObjectOnTrack(blocks, mapObjects, Config.WALL_MAP_OBJECT, zIndexForObstacles)
+        blockObjectCreator.placeObjectOnTrack(blocks, mapObjects, Config.MUD_MAP_OBJECT, 0.1)
+        blockObjectCreator.placeObjectOnTrack(blocks, mapObjects, Config.WALL_MAP_OBJECT, 0.2)
 
-        val zIndexForPowerups = 0.9
-        blockObjectCreator.placeObjectOnTrack(blocks, mapObjects, Config.BOOST_MAP_OBJECT, zIndexForPowerups)
-        blockObjectCreator.placeObjectOnTrack(blocks, mapObjects, Config.OIL_ITEM_MAP_OBJECT, zIndexForPowerups)
-        blockObjectCreator.placeObjectOnTrack(blocks, mapObjects, Config.LIZARD_MAP_OBJECT, zIndexForPowerups)
-        blockObjectCreator.placeObjectOnTrack(blocks, mapObjects, Config.TWEET_MAP_OBJECT, zIndexForPowerups)
-        blockObjectCreator.placeObjectOnTrack(blocks, mapObjects, Config.EMP_MAP_OBJECT, zIndexForPowerups)
+        blockObjectCreator.placeObjectOnTrack(blocks, mapObjects, Config.BOOST_MAP_OBJECT, 0.9)
+        blockObjectCreator.placeObjectOnTrack(blocks, mapObjects, Config.OIL_ITEM_MAP_OBJECT, 0.8)
+        blockObjectCreator.placeObjectOnTrack(blocks, mapObjects, Config.LIZARD_MAP_OBJECT, 0.6)
+        blockObjectCreator.placeObjectOnTrack(blocks, mapObjects, Config.TWEET_MAP_OBJECT, 0.5)
+        blockObjectCreator.placeObjectOnTrack(blocks, mapObjects, Config.EMP_MAP_OBJECT, 0.4)
 
         setPlayerOneStartPosition(blocks)
         setPlayerTwoStartPosition(blocks)

--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarMapGenerator.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarMapGenerator.scala
@@ -64,7 +64,7 @@ class CarMapGenerator(seed: Int) extends GameMapGenerator {
         val mapObjects = mutable.SortedMap[Double, Int]()
         mapObjects.put(0.0, Config.EMPTY_MAP_OBJECT)
         mapObjects.put(((Config.MUD_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.29, Config.MUD_MAP_OBJECT)
-        mapObjects.put(mapObjects.lastKey + ((Config.BOOST_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.182, Config.BOOST_MAP_OBJECT)
+        mapObjects.put(mapObjects.lastKey + ((Config.BOOST_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.189, Config.BOOST_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.OIL_ITEM_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.2, Config.OIL_ITEM_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.WALL_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.405, Config.WALL_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.LIZARD_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.185, Config.LIZARD_MAP_OBJECT)

--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarMapGenerator.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarMapGenerator.scala
@@ -69,7 +69,7 @@ class CarMapGenerator(seed: Int) extends GameMapGenerator {
         mapObjects.put(mapObjects.lastKey + ((Config.WALL_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.405, Config.WALL_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.LIZARD_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.203, Config.LIZARD_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.TWEET_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.22 , Config.TWEET_MAP_OBJECT)
-        mapObjects.put(mapObjects.lastKey + ((Config.EMP_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.21, Config.EMP_MAP_OBJECT)
+        mapObjects.put(mapObjects.lastKey + ((Config.EMP_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.24, Config.EMP_MAP_OBJECT)
         mapObjects.put(1.0, Config.EMPTY_MAP_OBJECT)
 
         //generate empty map

--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarMapGenerator.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarMapGenerator.scala
@@ -67,7 +67,7 @@ class CarMapGenerator(seed: Int) extends GameMapGenerator {
         mapObjects.put(mapObjects.lastKey + ((Config.BOOST_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.189, Config.BOOST_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.OIL_ITEM_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.21, Config.OIL_ITEM_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.WALL_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.405, Config.WALL_MAP_OBJECT)
-        mapObjects.put(mapObjects.lastKey + ((Config.LIZARD_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.185, Config.LIZARD_MAP_OBJECT)
+        mapObjects.put(mapObjects.lastKey + ((Config.LIZARD_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.203, Config.LIZARD_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.TWEET_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.22 , Config.TWEET_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.EMP_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.21, Config.EMP_MAP_OBJECT)
         mapObjects.put(1.0, Config.EMPTY_MAP_OBJECT)

--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarMapGenerator.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarMapGenerator.scala
@@ -65,7 +65,7 @@ class CarMapGenerator(seed: Int) extends GameMapGenerator {
         mapObjects.put(0.0, Config.EMPTY_MAP_OBJECT)
         mapObjects.put(((Config.MUD_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.29, Config.MUD_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.BOOST_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.189, Config.BOOST_MAP_OBJECT)
-        mapObjects.put(mapObjects.lastKey + ((Config.OIL_ITEM_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.2, Config.OIL_ITEM_MAP_OBJECT)
+        mapObjects.put(mapObjects.lastKey + ((Config.OIL_ITEM_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.21, Config.OIL_ITEM_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.WALL_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.405, Config.WALL_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.LIZARD_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.185, Config.LIZARD_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.TWEET_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.2, Config.TWEET_MAP_OBJECT)

--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarMapGenerator.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarMapGenerator.scala
@@ -66,7 +66,7 @@ class CarMapGenerator(seed: Int) extends GameMapGenerator {
         mapObjects.put(((Config.MUD_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.29, Config.MUD_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.BOOST_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.182, Config.BOOST_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.OIL_ITEM_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.2, Config.OIL_ITEM_MAP_OBJECT)
-        mapObjects.put(mapObjects.lastKey + ((Config.WALL_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.165, Config.WALL_MAP_OBJECT)
+        mapObjects.put(mapObjects.lastKey + ((Config.WALL_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.405, Config.WALL_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.LIZARD_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.185, Config.LIZARD_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.TWEET_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.2, Config.TWEET_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.EMP_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.21, Config.EMP_MAP_OBJECT)

--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarMapGenerator.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarMapGenerator.scala
@@ -68,7 +68,7 @@ class CarMapGenerator(seed: Int) extends GameMapGenerator {
         mapObjects.put(mapObjects.lastKey + ((Config.OIL_ITEM_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.21, Config.OIL_ITEM_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.WALL_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.405, Config.WALL_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.LIZARD_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.185, Config.LIZARD_MAP_OBJECT)
-        mapObjects.put(mapObjects.lastKey + ((Config.TWEET_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.2, Config.TWEET_MAP_OBJECT)
+        mapObjects.put(mapObjects.lastKey + ((Config.TWEET_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.22 , Config.TWEET_MAP_OBJECT)
         mapObjects.put(mapObjects.lastKey + ((Config.EMP_GENERATION_PERCENTAGE * 0.01) + 0.01) * 0.21, Config.EMP_MAP_OBJECT)
         mapObjects.put(1.0, Config.EMPTY_MAP_OBJECT)
 

--- a/game-engine/src/test/scala/MapGeneration_Tests.scala
+++ b/game-engine/src/test/scala/MapGeneration_Tests.scala
@@ -34,6 +34,8 @@ class MapGeneration_Tests extends FunSuite {
 
       println("avg number of mud blocks: " + averageNumberOfMudBlocksGenerated)
       println("max allowed mud blocks: " + maxAllowedNumberOfMudBlocks)
+      println("acceptable difference: " + deviationInTermsOfNumberOfObjects)
+
       assert(Math.abs(maxAllowedNumberOfMudBlocks - averageNumberOfMudBlocksGenerated) <= deviationInTermsOfNumberOfObjects, "Mud blocks not generated not within bounds");
   }
 
@@ -58,6 +60,7 @@ class MapGeneration_Tests extends FunSuite {
 
       println("avg number of wall blocks: " + averageNumberOfWallBlocksGenerated)
       println("max allowed wall blocks: " + maxAllowedNumberOfWallBlocks)
+      println("acceptable difference: " + deviationInTermsOfNumberOfObjects)
       assert(Math.abs(maxAllowedNumberOfWallBlocks - averageNumberOfWallBlocksGenerated) <= deviationInTermsOfNumberOfObjects, "Wall blocks not generated not within bounds");
   }
 
@@ -82,6 +85,7 @@ class MapGeneration_Tests extends FunSuite {
 
       println("avg number of boost blocks: " + averageNumberOfBoostPickupBlocksGenerated)
       println("max allowed boost blocks: " + maxAllowedNumberOfBoostPickupBlocks)
+      println("acceptable difference: " + deviationInTermsOfNumberOfObjects)
       assert(Math.abs(maxAllowedNumberOfBoostPickupBlocks - averageNumberOfBoostPickupBlocksGenerated) <= deviationInTermsOfNumberOfObjects, "Boost pickup blocks not generated not within bounds");
   }
 
@@ -106,6 +110,7 @@ class MapGeneration_Tests extends FunSuite {
 
       println("avg number of oil blocks: " + averageNumberOfOilPickupBlocksGenerated)
       println("max allowed oil blocks: " + maxAllowedNumberOfOilPickupBlocks)
+    println("acceptable difference: " + deviationInTermsOfNumberOfObjects)
       assert(Math.abs(maxAllowedNumberOfOilPickupBlocks - averageNumberOfOilPickupBlocksGenerated) <= deviationInTermsOfNumberOfObjects, "Oil pickup blocks not generated not within bounds");
   }
 
@@ -130,6 +135,7 @@ class MapGeneration_Tests extends FunSuite {
 
     println("avg number of tweet blocks: " + averageNumberOfTweetPickupBlocksGenerated)
     println("max allowed tweet blocks: " + maxAllowedNumberOfTweetPickupBlocks)
+    println("acceptable difference: " + deviationInTermsOfNumberOfObjects)
     assert(Math.abs(maxAllowedNumberOfTweetPickupBlocks - averageNumberOfTweetPickupBlocksGenerated) <= deviationInTermsOfNumberOfObjects, "Tweet pickup blocks not generated not within bounds");
   }
 
@@ -154,6 +160,7 @@ class MapGeneration_Tests extends FunSuite {
 
       println("avg number of lizard blocks: " + averageNumberOfLizardPickupBlocksGenerated)
       println("max allowed lizard blocks: " + maxAllowedNumberOfLizardPickupBlocks)
+    println("acceptable difference: " + deviationInTermsOfNumberOfObjects)
       assert(Math.abs(maxAllowedNumberOfLizardPickupBlocks - averageNumberOfLizardPickupBlocksGenerated) <= deviationInTermsOfNumberOfObjects, "Lizard pickup blocks not generated not within bounds");
   }
 
@@ -178,6 +185,7 @@ class MapGeneration_Tests extends FunSuite {
 
       println("avg number of emp blocks: " + averageNumberOfEmpPickupBlocksGenerated)
       println("max allowed emp blocks: " + maxAllowedNumberOfEmpPickupBlocks)
+    println("acceptable difference: " + deviationInTermsOfNumberOfObjects)
       assert(Math.abs(maxAllowedNumberOfEmpPickupBlocks - averageNumberOfEmpPickupBlocksGenerated) <= deviationInTermsOfNumberOfObjects, "Lizard pickup blocks not generated not within bounds");
   }
 


### PR DESCRIPTION
- put each obstacle / powerup on its on z plane
- closes #96 