### PR TITLE
Attempted fix for #124 (EMP issue)

### DIFF
--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarGamePlayer.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarGamePlayer.scala
@@ -141,10 +141,13 @@ class CarGamePlayer(health: Int, var score: Int, gamePlayerId: Int, var speed: I
     }
 
     def hitEmp(): Unit = {
-        val allowStop: Boolean = false
-        reduceSpeedToLevel(allowStop, SPEED_STATE_1)
         setState(Config.HIT_EMP_PLAYER_STATE)
         updateScore(Config.HIT_EMP_SCORE_PENALTY)
+    }
+
+    def hitEmpReduceSpeed(): Unit = {
+        val allowStop: Boolean = false
+        reduceSpeedToLevel(allowStop, SPEED_STATE_1)
     }
 
     private def reduceSpeedToLevel(allowStop: Boolean, speedLevel: Int) = {

--- a/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarGameRoundProcessor.scala
+++ b/game-engine/src/main/scala/za/co/entelect/challenge/game/contracts/game/CarGameRoundProcessor.scala
@@ -38,7 +38,7 @@ class CarGameRoundProcessor extends GameRoundProcessor{
       playerCommand.performCommand(gameMap, gamePlayer)
     }
 
-    //make sure players hit by EMP do not move
+    //make sure players hit by EMP do not move and that their speed is reduced
     for ( i <- gamePlayers.indices) {
       val gamePlayer = gamePlayers(i)
       val carGamePlayer = gamePlayer.asInstanceOf[CarGamePlayer]
@@ -46,6 +46,7 @@ class CarGameRoundProcessor extends GameRoundProcessor{
       if(hitByEmp) {
         val stagedPositionToUpdate = carGameMap.stagedFuturePositions.find(x => x.getPlayer().getGamePlayerId() == carGamePlayer.getGamePlayerId()).get
         stagedPositionToUpdate.setNewPosition(stagedPositionToUpdate.getOldPosition())
+        carGamePlayer.hitEmpReduceSpeed()
       }
     }
 

--- a/game-engine/src/test/scala/Command_Use_Emp_Tests.scala
+++ b/game-engine/src/test/scala/Command_Use_Emp_Tests.scala
@@ -198,9 +198,38 @@ class Command_Use_Emp_Tests extends FunSuite{
     TestHelper.processRound(gameMap, nothingCommand, accelerateCommand)
     TestHelper.processRound(gameMap, useEmpCommand, accelerateCommand)
 
-    assert(testCarGamePlayer2.speed == Config.SPEED_STATE_2)
+    assert(testCarGamePlayer2.speed == Config.SPEED_STATE_1)
   }
 
+  test("Given player2 with emp behind player1, one lane away, when USE_EMP command player1 slows down") {
+    initialise()
+    val gameMap = TestHelper.initialiseGameWithNoMapObjects()
+    val carGameMap = gameMap.asInstanceOf[CarGameMap]
+
+    val testGamePlayer1 = TestHelper.getTestGamePlayer1()
+    val testCarGamePlayer1 = testGamePlayer1.asInstanceOf[CarGamePlayer]
+    TestHelper.putPlayerSomewhereOnTheTrack(carGameMap, testCarGamePlayer1.getGamePlayerId(), 4, 100)
+
+    val testGamePlayer2 = TestHelper.getTestGamePlayer2()
+    val testCarGamePlayer2 = testGamePlayer2.asInstanceOf[CarGamePlayer]
+    TestHelper.putPlayerSomewhereOnTheTrack(carGameMap, testCarGamePlayer2.getGamePlayerId(), 3, 40)
+
+    testCarGamePlayer1.speed = Config.SPEED_STATE_3
+    testCarGamePlayer2.speed = Config.SPEED_STATE_3
+
+    testCarGamePlayer2.pickupEmp()
+    TestHelper.processRound(gameMap, nothingCommand, nothingCommand)
+    TestHelper.processRound(gameMap, nothingCommand, useEmpCommand)
+
+    assert(testCarGamePlayer1.speed == Config.SPEED_STATE_1)
+
+
+    testCarGamePlayer2.pickupEmp()
+    TestHelper.processRound(gameMap, accelerateCommand, nothingCommand)
+    TestHelper.processRound(gameMap, accelerateCommand, useEmpCommand)
+
+    assert(testCarGamePlayer1.speed == Config.SPEED_STATE_1)
+  }
 
   test("Given player1 with emp behind player2, two lanes away, when USE_EMP command nothing happens") {
     initialise()


### PR DESCRIPTION
Hi, I took a stab at fixing #124 by making it so that the EMP's speed reduction only gets applied after the round's commands has been processed. This way player 1 and 2 is treated equally when hit by an EMP (verified by added test). This has the effect that regardless of what command a player issues, if their hit by an EMP their speed is reduced to 3 on the next round (correct behaviour as I understand the rules).